### PR TITLE
Initial script edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # TargetedTilingPrimers
 Create mutation targeting primers tiling codons of a gene for codon mutagenesis
+
+This repository contains information and a Python script for designing primers to generate mutant libraries of genes with specific desired mutations at each site.
+
+## Codon mutagenesis
+
+Codon mutagenesis can be used to create mutant libraries of a gene with all possible codon mutations.
+Such libraries are useful for experiments such as [deep mutational scanning](https://www.ncbi.nlm.nih.gov/pubmed/25075907) or [mutational antigenic profiling](http://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1006271)
+
+A [script in a separate repository](https://github.com/jbloomlab/CodonTilingPrimers) can be used to generate random mutations at each codon in a gene. This protocol randomly mutates each codon to all other possible codons. This protocol and papers using it are also described in that repository.
+
+Rather than generating mutant libraries with all possible codon mutations at every site in a gene, the script in this repository can be used to generate primers that will result in specific desired mutations at each site in a gene. In this way, a mutant library can be generated which has fewer lethal mutations than random codon mutagenesis.
+
+## Running the script to design primers
+
+The [create_primers.py](create_primers.py) Python script can be used to create primers that tile the codons of a gene in both the forward and reverse direction. Each pair of foward and reverse primers will produce one specified mutation at one specified site. The desired mutations must be given as a csv file argument.
+
+### Required arguments
+
+*seq* : Text file containing the sequence of the gene. The gene itself should be upper case, including the start and stop codons. Any flanking regions should be lower case. There must be >= (primerlength - 3) / 2.0 nucleotides before the first codon mutagenized and after the last codon mutagenized, otherwise there would not be enough flanking nucleotides for a primer to mutate those codons.
+
+*mutations_csv* : csv file containing a table with the mutations the primers will make to seq. The table should have a column, 'site', with site numbers, and a column, 'mutant', with the single letter amino acid mutant to make at that site. Each site can have multiple mutants, or none. The site number should denote the number of the codon in the uppercase gene, with the start codon being 1.
+
+*codon_frequency_csv* : csv file containing a table with codon frequencies used to determine which codons sites will be mutated to. The table should have the columns 'aa', 'codon', and 'frequency'. Each row should have one single letter amino acid in 'aa', one codon corresponding to that amino acid in 'codon', and the frequency of that codon in 'frequency'. The script uses the codon with the highest frequency to replace the codon at a site to make mutations. Codon frequency tables for different organisms can be found [here](https://www.kazusa.or.jp/codon/).
+
+*primerlength* : length of primers. Must be an odd number, so that there is equal length flanking on each side.
+
+*prefix* : string prefix attached to primer names.
+
+The script takes command line arguments; for a listing of how to provide the arguments, type the following to get the help message:
+
+`python create_primers.py -h`
+
+### Optional parameters
+
+There are a variety of optional parameters specifying primer length and melting temperature constraints; the default values for these optional parameters are displayed when you run the program with the `-h` option to get the help message.
+
+## How the script works
+
+The script works as follows:
+
+    1) `mutations_csv` is used to determine what mutations will be made at what sites.
+
+    2) For each site, the frequencies from `codon_frequency_csv` are used to determine what the most frequent codon is for each mutation to be made at that site. This codon will be made by the primer for that mutation at that site.
+
+    3) For each mutant codon, it first makes an ORIGINAL primer of the length specified by `--startprimerlength`
+
+    4) If the original primer has a melting temperature (Tm) greater than the value specified by `--maxprimertm`, then nucleotides are trimmed off one by one (first from the 5' end, then the 3' end, then the 5' end again, etc) until the melting temperature is less than `--maxprimertm` or the length is reduced to `--minlength`.
+
+    5) If the original primer has a Tm greater than `--minprimertm`, then nucleotides are added one-by-one (first to the 3' end, then the 5' end, then the 3' end again, etc) until the melting temperature is greater than `--minprimertm` or the length reaches `--maxlength`.
+
+Note that because the primers are constrained to be between `--minprimerlength` and `--maxprimerlength`, the Tm may not always fall between `--minprimertm` and `--maxprimertm`. This can also happen if a primer initially exceeds `--maxprimertm` but the first trimming that drops it below this value also drops it below `--minprimertm`, or vice-versa if the primer is being extended to increase its melting temperature.
+
+The  *Tm_NN* command of the [MeltingTemp module of Biopython](http://biopython.org/DIST/docs/api/Bio.SeqUtils.MeltingTemp-module.html) is used to calculate Tm of primers.
+This calculation is based on nearest neighbor thermodynamics.
+
+The result of running this script is the file specified by `outfile`. It lists the primers.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository contains information and a Python script for designing primers t
 Codon mutagenesis can be used to create mutant libraries of a gene with all possible codon mutations.
 Such libraries are useful for experiments such as [deep mutational scanning](https://www.ncbi.nlm.nih.gov/pubmed/25075907) or [mutational antigenic profiling](http://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1006271)
 
-A [script in a separate repository](https://github.com/jbloomlab/CodonTilingPrimers) can be used to generate random mutations at each codon in a gene. This protocol randomly mutates each codon to all other possible codons. This protocol and papers using it are also described in that repository.
+A [script in a separate repository](https://github.com/jbloomlab/CodonTilingPrimers) can be used to generate random mutations at each codon in a gene using degenerate primers. This protocol randomly mutates each codon to all other possible codons. This protocol and papers using it are also described in that repository.
 
-Rather than generating mutant libraries with all possible codon mutations at every site in a gene, the script in this repository can be used to generate primers that will result in specific desired mutations at each site in a gene. In this way, a mutant library can be generated which has fewer lethal mutations than random codon mutagenesis.
+Rather than generating mutant libraries with all possible codon mutations at every site in a gene using degenerate primers, the script in this repository can be used to generate primers that will result in specific desired mutations at each site in a gene. In this way, a mutant library can be generated which has fewer lethal mutations than all possible amino acid mutations.
 
 ## Running the script to design primers
 
@@ -20,7 +20,7 @@ The [create_primers.py](create_primers.py) Python script can be used to create p
 
 *seq* : Text file containing the sequence of the gene. The gene itself should be upper case, including the start and stop codons. Any flanking regions should be lower case. There must be >= (primerlength - 3) / 2.0 nucleotides before the first codon mutagenized and after the last codon mutagenized, otherwise there would not be enough flanking nucleotides for a primer to mutate those codons.
 
-*mutations_csv* : csv file containing a table with the mutations the primers will make to seq. The table should have a column, 'site', with site numbers, and a column, 'mutant', with the single letter amino acid mutant to make at that site. Each site can have multiple mutants, or none. The site number should denote the number of the codon in the uppercase gene, with the start codon being 1.
+*mutations_csv* : csv file containing a table with the mutations the primers will make to seq. The table should have a column, 'site', with site numbers, and a column, 'mutant', with the single letter amino acid mutant to make at that site. Each site can have multiple mutants, or none. The site number should denote the number of the codon in the uppercase gene, with the start codon being 1. If you want multiple mutations at the same site, there should be a separate row for each mutation.
 
 *codon_frequency_csv* : csv file containing a table with codon frequencies used to determine which codons sites will be mutated to. The table should have the columns 'aa', 'codon', and 'frequency'. Each row should have one single letter amino acid in 'aa', one codon corresponding to that amino acid in 'codon', and the frequency of that codon in 'frequency'. The script uses the codon with the highest frequency to replace the codon at a site to make mutations. Codon frequency tables for different organisms can be found [here](https://www.kazusa.or.jp/codon/).
 

--- a/create_primers.py
+++ b/create_primers.py
@@ -1,21 +1,35 @@
 """Script for creating gene assembly primers.
 
-Primers containing specified mutageneic codons at their center are tiled along a gene.
+Primers containing specified mutageneic codons at their center are tiled along
+a gene.
 
-Edited by Caelan Radford in 2020, from the CodonTilingPrimers code written by Jesse Bloom in 2013 and edited by Adam Dingens Nov 2015 to generate primers of differing lengths to all have a Tm of ~60C.
+Edited by Caelan Radford in 2020, from the CodonTilingPrimers code written by
+Jesse Bloom in 2013 and edited by Adam Dingens Nov 2015 to generate primers of
+differing lengths to all have a Tm of ~60C.
 
 This script first makes an ORIGINAL primer of specified length (default 37 bps).
-If the ORIGINAL primer has a Tm of greater than MaxPrimerTm, then nucleotides are trimmed off one by one (first 5', then 3', then 5' etc) until the Tm is less than MaxPrimerTm. Note that this could be over a degree less than the MaxPrimerTm.
-If the ORIGINAL primer has a Tm less than MinPrimerTm, then nucelotides are added one by one (first 3', then 5', then 3' etc) until the Tm is over MinPrimerTm. Note that this could be over a degree more than the MinPrimerTm
-If the ORIGINAL primer has a Tm of less than MaxPrimerTm but greater than MinPrimerTm, it is not altered.
-The primers are constrained to be between MinPrimerlength and MaxPrimerLength bps long. The Tm of some MaxPrimerLength primers may not be > MinPrimerTemp, and the Tm of some MinPrimerLength primers may not be < MaxPrimerTm.
+If the ORIGINAL primer has a Tm of greater than MaxPrimerTm, then nucleotides
+are trimmed off one by one (first 5', then 3', then 5' etc) until the Tm is less
+than MaxPrimerTm. Note that this could be over a degree less than the
+MaxPrimerTm.
+If the ORIGINAL primer has a Tm less than MinPrimerTm, then nucelotides are
+added one by one (first 3', then 5', then 3' etc) until the Tm is over
+MinPrimerTm. Note that this could be over a degree more than the MinPrimerTm
+If the ORIGINAL primer has a Tm of less than MaxPrimerTm but greater than
+MinPrimerTm, it is not altered.
+The primers are constrained to be between MinPrimerlength and MaxPrimerLength
+bps long. The Tm of some MaxPrimerLength primers may not be > MinPrimerTemp,
+and the Tm of some MinPrimerLength primers may not be < MaxPrimerTm.
 
 For command line arguments, run::
 
     python create_primers.py -h
 
-The  Tm_NN command of the MeltingTemp Module of Biopython (http://biopython.org/DIST/docs/api/Bio.SeqUtils.MeltingTemp-module.html) is used to calculate Tm of primers.
-This calculation is based on nearest neighbor thermodynamics. nucelotides labeled N are given average values in the Tm calculation.
+The  Tm_NN command of the MeltingTemp Module of Biopython
+(http://biopython.org/DIST/docs/api/Bio.SeqUtils.MeltingTemp-module.html) is
+used to calculate Tm of primers.
+This calculation is based on nearest neighbor thermodynamics. nucelotides
+labeled N are given average values in the Tm calculation.
 It is possible to vary salt concentration and other addatives if needed."""
 
 
@@ -32,33 +46,63 @@ from Bio.Seq import Seq
 def Parser():
     """Returns command line parser."""
     parser = argparse.ArgumentParser(
-            description='Script by Caelan Radford, Adam Dingens, and Jesse Bloom to design specified codon tiling primers with specific melting temperatures.',
+            description='Script by Caelan Radford, Adam Dingens, and Jesse '
+            'Bloom to design specified codon tiling primers with specific '
+            'melting temperatures.',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
             )
 
-    parser.add_argument('sequencefile', help="the name of a file giving the sequence for which we are designing the primers. This file should only contain the sequence, and should not have any headers or other content. For the sequence, make the 5' and 3' ends that you do not want to mutate in lower case. Make the portion of the coding sequence that you want to tile with ambiguous codons in upper case. Typically, for example, the first site you mutate would be the initial start codon, so the first *ATG* would be the first upper case letter. You must have at least *(startprimerlength - 3) / 2* nucleotides in lower case at each end of the upper case sequence that you are mutating. This is because at least this much flanking sequence is needed to design primers of the indicated length; more sequence may be required if the primer at either end is extended beyond the startprimerlength.")
-    parser.add_argument('mutations_csv', help="the name of a csv file containing a table of specific mutations per site you want to make. It should have one column ('site') with site numbers and one column ('mutant') with amino acid mutants to make at that site. Site 1 is the first codon in the uppercase sequence.")
-    parser.add_argument('codon_frequency_csv', help="the name of a csv file with a table of codon frequencies to be used to determine which codons to mutate to. It should have one column 'aa' with single letter amino acids, one column 'codon' with codons, and one column 'frequency' with codon frequencies. The highest frequency codon for each amino acid is used.")
-    parser.add_argument('primerprefix', help="prefix name to be added to each primer")
+    parser.add_argument('sequencefile', help="the name of a file giving the "
+    "sequence for which we are designing the primers. This file should only "
+    "contain the sequence, and should not have any headers or other content. "
+    "For the sequence, make the 5' and 3' ends that you do not want to mutate "
+    "in lower case. Make the portion of the coding sequence that you want to "
+    "tile with ambiguous codons in upper case. Typically, for example, the "
+    "first site you mutate would be the initial start codon, so the first "
+    "*ATG* would be the first upper case letter. You must have at least "
+    "*(startprimerlength - 3) / 2* nucleotides in lower case at each end of "
+    "the upper case sequence that you are mutating. This is because at least "
+    "this much flanking sequence is needed to design primers of the indicated "
+    "length; more sequence may be required if the primer at either end is "
+    "extended beyond the startprimerlength.")
+    parser.add_argument('mutations_csv', help="the name of a csv file "
+    "containing a table of specific mutations per site you want to make. It "
+    "should have one column ('site') with site numbers and one column "
+    "('mutant') with amino acid mutants to make at that site. Site 1 is the "
+    "first codon in the uppercase sequence. If you want multiple mutations"
+    "at the same site, there should be a separate row for each mutation.")
+    parser.add_argument('codon_frequency_csv', help="the name of a csv file "
+    "with a table of codon frequencies to be used to determine which codons to "
+    "mutate to. It should have one column 'aa' with single letter amino acids, "
+    "one column 'codon' with codons, and one column 'frequency' with codon "
+    "frequencies. The highest frequency codon for each amino acid is used.")
+    parser.add_argument('primerprefix', help="prefix name to be added to each "
+    "primer")
     parser.add_argument('outfile', help='name of primer output file')
-    parser.add_argument('--startprimerlength', type=int, help='starting primer length', default=37)
-    parser.add_argument('--maxprimertm', type=float, help="Upper temperature limit for primers.", default=61)
-    parser.add_argument('--minprimertm', type=float, help="Lower temperature limit for primers.", default=60)
-    parser.add_argument('--minlength', type=int, help='Minimum primer length', default=25)
-    parser.add_argument('--maxlength', type=int, help='Maximum primer length', default=51)
+    parser.add_argument('--startprimerlength', type=int, help="starting "
+    "primer length", default=37)
+    parser.add_argument('--maxprimertm', type=float, help="Upper temperature "
+    "limit for primers.", default=61)
+    parser.add_argument('--minprimertm', type=float, help="Lower temperature "
+    "limit for primers.", default=60)
+    parser.add_argument('--minlength', type=int, help='Minimum primer length',
+    default=25)
+    parser.add_argument('--maxlength', type=int, help='Maximum primer length',
+    default=51)
     return parser
 
 
 def ReverseComplement(seq):
     """Returns reverse complement of sequence. Preserves upper/lower case."""
-    d = {'A':'T', 'T':'A', 'C':'G', 'G':'C', 'a':'t', 't':'a', 'c':'g', 'g':'c', 'N':'N', 'n':'n', 'S':'S', 's':'s', 'K':'M', 'k':'m'}
+    d = {'A':'T', 'T':'A', 'C':'G', 'G':'C', 'a':'t', 't':'a', 'c':'g', 'g':'c'}
     rc = [d[nt] for nt in seq]
     rc.reverse()
     return ''.join(rc)
 
 
-def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
-    """Creates oligos to tile a gene and introduce specified amino acid mutations at each site.
+def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv,
+primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
+    """Creates oligos to introduce specified amino acid mutations at each site.
 
     *seq* : sequence of the gene. The gene itself should be upper case,
     including the start and stop codons. Any flanking regions should be lower
@@ -71,7 +115,8 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
     numbers, and one column, 'mutant', with the single letter amino acid mutant
     to make at that site. Each site can have mulitple mutants, or none. The site
     number should denote the number of the codon in the uppercase gene, with the
-    start codon being 1.
+    start codon being 1. If you want multiple mutations at the same site, there
+    should be a separate row for each mutation.
 
     *codon_frequency_csv* :  csv file containing a table with codon frequencies
     used to determine which codons sites will be mutated to. The table should
@@ -82,8 +127,8 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
     make mutations. Codon frequency tables for different organisms can be found
     [here](https://www.kazusa.or.jp/codon/).
 
-    *primerlength* : length of primers. Must be an odd number, so that equal length
-    flanking on each side.
+    *primerlength* : length of primers. Must be an odd number, so that equal
+    length flanking on each side.
 
     *prefix* : string prefix attached to primer names.
 
@@ -97,12 +142,14 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
 
     Returns a list of all these primers as *(name, sequence)* 2-tuples.
     """
-    n = len(seq)
-    assert primerlength % 2 == 1, "primer length not odd"
+    if primerlength % 2 != 1:
+        raise ValueError("Primer length not odd")
     initial_flanklength = (primerlength - 3) // 2
     upperseq = ''.join([nt for nt in seq if nt.istitle()])
-    assert upperseq in seq, "upper case nucleotides not substring"
-    assert len(upperseq) % 3 == 0, "length of upper case not multiple of 3"
+    if upperseq not in seq:
+        raise ValueError("Upper case nucleotides not substring")
+    if len(upperseq) % 3 != 0:
+        raise ValueError("Length of upper case not multiple of 3")
     ncodons = len(upperseq) // 3
 
     # Read in the mutations csv and make sure it is the right format
@@ -110,11 +157,11 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
     try:
         sites = df['site'].tolist()
     except:
-        print('mutations_csv must have column "site"')
+        print("mutations_csv must have column 'site'")
     try:
         mutations = df['mutant'].tolist()
     except:
-        print('mutations_csv must have column "mutant"')
+        print("mutations_csv must have column 'mutant'")
     mutations_dict = {}
     for i, site in enumerate(sites):
         if site not in mutations_dict:
@@ -122,14 +169,15 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
         else:
             mutations_dict[site].append(mutations[i])
     # Make sure this is enough flanking sequence to make primers
-    initial_flanklength = (primerlength - 3) // 2
     firstcodon = min(sites)
     lastcodon = max(sites)
-    startupper = seq.index(upperseq) + ((firstcodon - 1) * 3)
-    if startupper < initial_flanklength:
-        raise ValueError("not enough 5' flanking nucleotides")
-    if n - len(upperseq) - seq.index(upperseq) + (len(upperseq) - (lastcodon - 1) * 3) < initial_flanklength:
-        raise ValueError("not enough 3' flanking nucleotides")
+    startupper = seq.index(upperseq)
+    if startupper + ((firstcodon - 1) * 3) < initial_flanklength:
+        raise ValueError("Not enough 5' flanking nucleotides")
+    n = len(seq)
+    lower_3_prime = n - len(upperseq) - seq.index(upperseq)
+    if lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3) < initial_flanklength:
+        raise ValueError("Not enough 3' flanking nucleotides")
     # Read in the codon frequency table, make dict for back translating
     df = pd.read_csv(codon_frequency_csv)
     aas = df['aa'].tolist()
@@ -146,17 +194,18 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
     # frequent codon. This could be changed later to have random option
     primers = []
     for icodon in range(ncodons):
-        codon_inserts = []
         if icodon + 1 in mutations_dict:
             for mutation in mutations_dict[icodon + 1]:
                 max_frequency = max(back_t_dict[mutation])
                 codon_insert = back_t_dict[mutation][max_frequency]
                 i = startupper + icodon * 3
-                primer = "%s%s%s" % (seq[i - initial_flanklength : i], codon_insert, seq[i + 3 : i + 3 + initial_flanklength])
+                five_prime = seq[i - initial_flanklength : i]
+                three_prime = seq[i + 3 : i + 3 + initial_flanklength]
+                primer = f"{five_prime}{codon_insert}{three_prime}"
                 name = f"{prefix}-for-mut{icodon + 1}{mutation}"
                 primerseq = Seq(primer)
 
-                TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                TmNN = mt.Tm_NN(primerseq, strict=False)
                 add_3 = True
                 minus_5 = True
                 flank5 = flank3 = initial_flanklength
@@ -164,41 +213,45 @@ def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv, primerl
                     while float(TmNN) > float(maxprimertm) and len(primer) > minlength:
                         if minus_5:
                             flank5 -= 1
-                            primer = "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+                            five_prime = seq[i - (flank5) : i]
+                            three_prime = seq[i + 3 : i + 3 + flank3]
+                            primer = f"{five_prime}{codon_insert}{three_prime}"
                             minus_5 = False
                         else:
                             flank3 -= 1
-                            primer =  "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
-
+                            five_prime = seq[i - (flank5) : i]
+                            three_prime = seq[i + 3 : i + 3 + flank3]
+                            primer = f"{five_prime}{codon_insert}{three_prime}"
                             minus_5 = True
                         if seq.index(upperseq) + ((firstcodon - 1) * 3) < flank5:
-                            raise ValueError("not enough 5' lower case flanking nucleotides")
-                        if n - len(upperseq) - seq.index(upperseq) + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
-                            raise ValueError("not enough 3' lower case flanking nucleotides")
-
-
+                            raise ValueError("Not enough 5' lower case flanking nucleotides")
+                        if lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
+                            raise ValueError("Not enough 3' lower case flanking nucleotides")
                         primerseq = Seq(primer)
-                        TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                        TmNN = mt.Tm_NN(primerseq, strict=False)
                         primerlength= len(primer)
                 else:
                     if float(TmNN) < float(minprimertm):
                         while float(TmNN) < float(minprimertm) and len(primer) < maxlength:
                             if add_3:
                                 flank3 += 1
-                                primer = "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+                                five_prime = seq[i - (flank5) : i]
+                                three_prime = seq[i + 3 : i + 3 + flank3]
+                                primer = f"{five_prime}{codon_insert}{three_prime}"
                                 add_3 = False
                             else:
                                 flank5 +=1
-                                primer = "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+                                five_prime = seq[i - (flank5) : i]
+                                three_prime = seq[i + 3 : i + 3 + flank3]
+                                primer = f"{five_prime}{codon_insert}{three_prime}"
                                 add_3 = True
                             primerseq = Seq(primer)
-                            TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                            TmNN = mt.Tm_NN(primerseq, strict=False)
                             primerlength= len(primer)
                             if seq.index(upperseq) + ((firstcodon - 1) * 3) < flank5:
-                                raise ValueError("not enough 5' lower case flanking nucleotides")
-                            if n - len(upperseq) - seq.index(upperseq) + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
-                                raise ValueError("not enough 3' lower case flanking nucleotides")
-
+                                raise ValueError("Not enough 5' lower case flanking nucleotides")
+                            if lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
+                                raise ValueError("Not enough 3' lower case flanking nucleotides")
                     else:
                         pass
                 primers.append((name, primer))
@@ -212,24 +265,24 @@ def main():
 
     print("Read the following command line arguments")
     for (argname, argvalue) in args.items():
-        print("\t%s = %s" % (argname, argvalue))
+        print(f"\t{argname} = {argvalue}")
 
 
     primerlength = args['startprimerlength']
 
     if (primerlength <=3 ) or (primerlength % 2 == 0):
-        raise ValueError("Does not appear to be valid primer length: %d" % primerlength)
+        raise ValueError(f"Does not appear to be valid primer length: {primerlength}")
 
     sequencefile = args['sequencefile']
     if not os.path.isfile(sequencefile):
-        raise IOError("Cannot find sequencefile %s" % sequencefile)
+        raise IOError(f"Cannot find sequencefile {sequencefile}")
     sequence = open(sequencefile).read()
     sequence = sequence.replace(' ', '')
     sequence = sequence.replace('\n', '')
-    print("Read a sequence of length %d from %s:\n%s" % (len(sequence), sequencefile, sequence))
+    print(f"Read a sequence of length {len(sequence)} from {sequencefile}:\n{sequence}")
     outfile = args['outfile']
     primerprefix = args['primerprefix']
-    print("The primers will be named with the prefix %s" % (primerprefix))
+    print(f"The primers will be named with the prefix {primerprefix}")
 
     mutations_csv = args['mutations_csv']
     if not os.path.isfile(mutations_csv):
@@ -240,32 +293,25 @@ def main():
         raise IOError(f"Cannot find mutatcodon_frequency_csvions_csv {codon_frequency_csv}")
 
     # Design forward mutation primers
-    mutforprimers = CreateMutForOligosVarLength(sequence, mutations_csv, codon_frequency_csv, primerlength, primerprefix, args['maxprimertm'], args['minprimertm'], args['maxlength'], args['minlength'])
-    print("Designed %d mutation forward primers." % len(mutforprimers))
+    mutforprimers = CreateMutForOligosVarLength(sequence, mutations_csv,
+        codon_frequency_csv, primerlength, primerprefix, args['maxprimertm'],
+        args['minprimertm'], args['maxlength'], args['minlength'])
+    print(f"Designed {len(mutforprimers)} mutation forward primers.")
 
     # Design reverse mutation primers
-    mutrevprimers = [(name.replace('for', 'rev'), ReverseComplement(seq)) for (name, seq) in mutforprimers]
-    print("Designed %d mutation reverse primers." % len(mutrevprimers))
+    mutrevprimers = [(name.replace('for', 'rev'), ReverseComplement(seq))
+                      for (name, seq) in mutforprimers]
+    print(f"Designed {len(mutrevprimers)} mutation reverse primers.")
 
     # Print out all of the primers
     primers = mutforprimers + mutrevprimers
-    print("This gives a total of %d primers." % len(primers))
+    print(f"This gives a total of {len(primers)} primers.")
 
-    print("\nNow writing these primers to %s" % outfile)
-    iplate = 1
+    print(f"\nNow writing these primers to {outfile}")
     f = open(outfile, 'w')
     for primers in [mutforprimers, mutrevprimers]:
-        f.write("\r\nPlate %d\r\n" % iplate)
-        n_in_plate = 0
         for (name, primer) in primers:
-            f.write("%s, %s\r\n" % (name, primer))
-            n_in_plate += 1
-            if n_in_plate == 96:
-                n_in_plate = 0
-                iplate += 1
-                f.write("\r\nPlate %d\r\n" % iplate)
-        if n_in_plate:
-            iplate += 1
+            f.write(f"{name}, {primer}\r\n")
 
 
 

--- a/create_primers.py
+++ b/create_primers.py
@@ -1,4 +1,5 @@
-"""Script for creating gene assembly primers.
+"""
+Script for creating gene assembly primers.
 
 Primers containing specified mutageneic codons at their center are tiled along
 a gene.
@@ -7,10 +8,11 @@ Edited by Caelan Radford in 2020, from the CodonTilingPrimers code written by
 Jesse Bloom in 2013 and edited by Adam Dingens Nov 2015 to generate primers of
 differing lengths to all have a Tm of ~60C.
 
-This script first makes an ORIGINAL primer of specified length (default 37 bps).
+This script first makes an ORIGINAL primer of specified length (default 37
+bps).
 If the ORIGINAL primer has a Tm of greater than MaxPrimerTm, then nucleotides
-are trimmed off one by one (first 5', then 3', then 5' etc) until the Tm is less
-than MaxPrimerTm. Note that this could be over a degree less than the
+are trimmed off one by one (first 5', then 3', then 5' etc) until the Tm is
+less than MaxPrimerTm. Note that this could be over a degree less than the
 MaxPrimerTm.
 If the ORIGINAL primer has a Tm less than MinPrimerTm, then nucelotides are
 added one by one (first 3', then 5', then 3' etc) until the Tm is over
@@ -30,14 +32,14 @@ The  Tm_NN command of the MeltingTemp Module of Biopython
 used to calculate Tm of primers.
 This calculation is based on nearest neighbor thermodynamics. nucelotides
 labeled N are given average values in the Tm calculation.
-It is possible to vary salt concentration and other addatives if needed."""
+It is possible to vary salt concentration and other addatives if needed.
+"""
 
 
 import os
-import sys
 import math
-import re
 import argparse
+
 import pandas as pd
 from Bio.SeqUtils import MeltingTemp as mt
 from Bio.Seq import Seq
@@ -52,80 +54,105 @@ def Parser():
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
             )
 
-    parser.add_argument('sequencefile', help="the name of a file giving the "
-    "sequence for which we are designing the primers. This file should only "
-    "contain the sequence, and should not have any headers or other content. "
-    "For the sequence, make the 5' and 3' ends that you do not want to mutate "
-    "in lower case. Make the portion of the coding sequence that you want to "
-    "tile with ambiguous codons in upper case. Typically, for example, the "
-    "first site you mutate would be the initial start codon, so the first "
-    "*ATG* would be the first upper case letter. You must have at least "
-    "*(startprimerlength - 3) / 2* nucleotides in lower case at each end of "
-    "the upper case sequence that you are mutating. This is because at least "
-    "this much flanking sequence is needed to design primers of the indicated "
-    "length; more sequence may be required if the primer at either end is "
-    "extended beyond the startprimerlength.")
-    parser.add_argument('mutations_csv', help="the name of a csv file "
-    "containing a table of specific mutations per site you want to make. It "
-    "should have one column ('site') with site numbers and one column "
-    "('mutant') with amino acid mutants to make at that site. Site 1 is the "
-    "first codon in the uppercase sequence. If you want multiple mutations"
-    "at the same site, there should be a separate row for each mutation.")
-    parser.add_argument('codon_frequency_csv', help="the name of a csv file "
-    "with a table of codon frequencies to be used to determine which codons to "
-    "mutate to. It should have one column 'aa' with single letter amino acids, "
-    "one column 'codon' with codons, and one column 'frequency' with codon "
-    "frequencies. The highest frequency codon for each amino acid is used.")
-    parser.add_argument('primerprefix', help="prefix name to be added to each "
-    "primer")
-    parser.add_argument('outfile', help='name of primer output file')
-    parser.add_argument('--startprimerlength', type=int, help="starting "
-    "primer length", default=37)
-    parser.add_argument('--maxprimertm', type=float, help="Upper temperature "
-    "limit for primers.", default=61)
-    parser.add_argument('--minprimertm', type=float, help="Lower temperature "
-    "limit for primers.", default=60)
-    parser.add_argument('--minlength', type=int, help='Minimum primer length',
-    default=25)
-    parser.add_argument('--maxlength', type=int, help='Maximum primer length',
-    default=51)
+    parser.add_argument('sequencefile',
+                        help="the name of a file giving the "
+                        "sequence for which we are designing the primers. This"
+                        "vfile should only contain the sequence, and should "
+                        "not have any headers or other content. For the "
+                        "sequence, make the 5' and 3' ends that you do not "
+                        "want to mutate in lower case. Make the portion of the"
+                        " coding sequence that you want to tile with mutant"
+                        " codons in upper case. Typically, for example, the "
+                        "first site you mutate would be the initial start "
+                        "codon, so the first *ATG* would be the first upper "
+                        "case letter. You must have at least "
+                        "*(startprimerlength - 3) / 2* nucleotides in lower "
+                        "case at each end of the upper case sequence that you "
+                        "are mutating. This is because at least this much "
+                        "flanking sequence is needed to design primers of the"
+                        " indicated length; more sequence may be required if "
+                        "the primer at either end is extended beyond the "
+                        "startprimerlength.")
+    parser.add_argument('mutations_csv',
+                        help="the name of a csv file containing a table of "
+                        "specific mutations per site you want to make. It "
+                        "should have one column ('site') with site numbers and"
+                        " one column ('mutant') with amino acid mutants to "
+                        "make at that site. Site 1 is the first codon in the "
+                        "uppercase sequence. If you want multiple mutations at"
+                        " the same site, there should be a separate row for "
+                        "each mutation.")
+    parser.add_argument('codon_frequency_csv',
+                        help="the name of a csv file with a table of codon "
+                        "frequencies to be used to determine which codons to "
+                        "mutate to. It should have one column 'aa' with single"
+                        " letter amino acids, one column 'codon' with codons, "
+                        "and one column 'frequency' with codon frequencies. "
+                        "The highest frequency codon for each amino acid is "
+                        "used.")
+    parser.add_argument('primerprefix',
+                        help="prefix name to be added to each primer")
+    parser.add_argument('outfile',
+                        help='name of primer output file')
+    parser.add_argument('--startprimerlength',
+                        type=int,
+                        help="starting primer length",
+                        default=37)
+    parser.add_argument('--maxprimertm',
+                        type=float,
+                        help="Upper temperature limit for primers.",
+                        default=61)
+    parser.add_argument('--minprimertm',
+                        type=float,
+                        help="Lower temperature limit for primers.",
+                        default=60)
+    parser.add_argument('--minlength',
+                        type=int,
+                        help='Minimum primer length',
+                        default=25)
+    parser.add_argument('--maxlength',
+                        type=int,
+                        help='Maximum primer length',
+                        default=51)
     return parser
 
 
 def ReverseComplement(seq):
     """Returns reverse complement of sequence. Preserves upper/lower case."""
-    d = {'A':'T', 'T':'A', 'C':'G', 'G':'C', 'a':'t', 't':'a', 'c':'g', 'g':'c'}
+    d = {'A': 'T', 'T': 'A', 'C': 'G', 'G': 'C', 'a': 't', 't': 'a', 'c': 'g',
+         'g': 'c'}
     rc = [d[nt] for nt in seq]
     rc.reverse()
     return ''.join(rc)
 
 
 def CreateMutForOligosVarLength(seq, mutations_csv, codon_frequency_csv,
-primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
+                                primerlength, prefix, maxprimertm,
+                                minprimertm, maxlength, minlength):
     """Creates oligos to introduce specified amino acid mutations at each site.
 
     *seq* : sequence of the gene. The gene itself should be upper case,
     including the start and stop codons. Any flanking regions should be lower
     case.
-    There must be >= (primerlength - 3) / 2.0 nucleotides before the first codon
-    mutagenized and after the last codon mutagenized.
+    There must be >= (primerlength - 3) / 2.0 nucleotides before the first
+    codon mutagenized and after the last codon mutagenized.
 
-    *mutations_csv* : csv file containing a table with the mutations the primers
-    will make to seq. The table should have one column, 'site', with site
-    numbers, and one column, 'mutant', with the single letter amino acid mutant
-    to make at that site. Each site can have mulitple mutants, or none. The site
-    number should denote the number of the codon in the uppercase gene, with the
-    start codon being 1. If you want multiple mutations at the same site, there
-    should be a separate row for each mutation.
+    *mutations_csv* : csv file containing a table with the mutations the
+    primers will make to seq. The table should have one column, 'site', with
+    site numbers, and one column, 'mutant', with the single letter amino acid
+    mutant to make at that site. Each site can have mulitple mutants, or none.
+    The site number should denote the number of the codon in the uppercase
+    gene, with the start codon being 1. If you want multiple mutations at the
+    same site, there should be a separate row for each mutation.
 
     *codon_frequency_csv* :  csv file containing a table with codon frequencies
     used to determine which codons sites will be mutated to. The table should
     have the columns 'aa', 'codon', and 'frequency'. Each row should have one
-    single letter amino acid in 'aa', one codon corresponding to that amino acid
-    in 'codon', and the frequency of that codon in 'frequency'. The script uses
-    the codon with the highest frequency to replace the codon at a site to
-    make mutations. Codon frequency tables for different organisms can be found
-    [here](https://www.kazusa.or.jp/codon/).
+    single letter amino acid in 'aa', one codon corresponding to that amino
+    acid in 'codon', and the frequency of that codon in 'frequency'. The
+    script uses the codon with the highest frequency to replace the codon at
+    a site to make mutations. Codon frequency tables for different organisms
+    can be found [here](https://www.kazusa.or.jp/codon/).
 
     *primerlength* : length of primers. Must be an odd number, so that equal
     length flanking on each side.
@@ -154,14 +181,8 @@ primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
 
     # Read in the mutations csv and make sure it is the right format
     df = pd.read_csv(mutations_csv)
-    try:
-        sites = df['site'].tolist()
-    except:
-        print("mutations_csv must have column 'site'")
-    try:
-        mutations = df['mutant'].tolist()
-    except:
-        print("mutations_csv must have column 'mutant'")
+    sites = df['site'].tolist()
+    mutations = df['mutant'].tolist()
     mutations_dict = {}
     for i, site in enumerate(sites):
         if site not in mutations_dict:
@@ -176,7 +197,8 @@ primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
         raise ValueError("Not enough 5' flanking nucleotides")
     n = len(seq)
     lower_3_prime = n - len(upperseq) - seq.index(upperseq)
-    if lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3) < initial_flanklength:
+    if (lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3)
+            < initial_flanklength):
         raise ValueError("Not enough 3' flanking nucleotides")
     # Read in the codon frequency table, make dict for back translating
     df = pd.read_csv(codon_frequency_csv)
@@ -199,63 +221,75 @@ primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
                 max_frequency = max(back_t_dict[mutation])
                 codon_insert = back_t_dict[mutation][max_frequency]
                 i = startupper + icodon * 3
-                five_prime = seq[i - initial_flanklength : i]
-                three_prime = seq[i + 3 : i + 3 + initial_flanklength]
+                five_prime = seq[i - initial_flanklength: i]
+                three_prime = seq[i + 3: i + 3 + initial_flanklength]
                 primer = f"{five_prime}{codon_insert}{three_prime}"
                 name = f"{prefix}-for-mut{icodon + 1}{mutation}"
                 primerseq = Seq(primer)
 
-                TmNN = mt.Tm_NN(primerseq, strict=False)
+                TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
                 add_3 = True
                 minus_5 = True
                 flank5 = flank3 = initial_flanklength
                 if float(TmNN) > float(maxprimertm):
-                    while float(TmNN) > float(maxprimertm) and len(primer) > minlength:
+                    while (float(TmNN) > float(maxprimertm) and
+                            len(primer) > minlength):
                         if minus_5:
                             flank5 -= 1
-                            five_prime = seq[i - (flank5) : i]
-                            three_prime = seq[i + 3 : i + 3 + flank3]
+                            five_prime = seq[i - (flank5): i]
+                            three_prime = seq[i + 3: i + 3 + flank3]
                             primer = f"{five_prime}{codon_insert}{three_prime}"
                             minus_5 = False
                         else:
                             flank3 -= 1
-                            five_prime = seq[i - (flank5) : i]
-                            three_prime = seq[i + 3 : i + 3 + flank3]
+                            five_prime = seq[i - (flank5): i]
+                            three_prime = seq[i + 3: i + 3 + flank3]
                             primer = f"{five_prime}{codon_insert}{three_prime}"
                             minus_5 = True
-                        if seq.index(upperseq) + ((firstcodon - 1) * 3) < flank5:
-                            raise ValueError("Not enough 5' lower case flanking nucleotides")
-                        if lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
-                            raise ValueError("Not enough 3' lower case flanking nucleotides")
+                        if (seq.index(upperseq) + ((firstcodon - 1) * 3) <
+                                flank5):
+                            raise ValueError("Not enough 5' lower case "
+                                             "flanking nucleotides")
+                        if (lower_3_prime + (len(upperseq) -
+                                (lastcodon - 1) * 3) < flank3):
+                            raise ValueError("Not enough 3' lower case "
+                                             "flanking nucleotides")
                         primerseq = Seq(primer)
-                        TmNN = mt.Tm_NN(primerseq, strict=False)
-                        primerlength= len(primer)
+                        TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                        primerlength = len(primer)
                 else:
                     if float(TmNN) < float(minprimertm):
-                        while float(TmNN) < float(minprimertm) and len(primer) < maxlength:
+                        while (float(TmNN) < float(minprimertm) and
+                                len(primer) < maxlength):
                             if add_3:
                                 flank3 += 1
-                                five_prime = seq[i - (flank5) : i]
-                                three_prime = seq[i + 3 : i + 3 + flank3]
-                                primer = f"{five_prime}{codon_insert}{three_prime}"
+                                five_prime = seq[i - (flank5): i]
+                                three_prime = seq[i + 3: i + 3 + flank3]
+                                primer = (f"{five_prime}{codon_insert}"
+                                          f"{three_prime}")
                                 add_3 = False
                             else:
-                                flank5 +=1
-                                five_prime = seq[i - (flank5) : i]
-                                three_prime = seq[i + 3 : i + 3 + flank3]
-                                primer = f"{five_prime}{codon_insert}{three_prime}"
+                                flank5 += 1
+                                five_prime = seq[i - (flank5): i]
+                                three_prime = seq[i + 3: i + 3 + flank3]
+                                primer = (f"{five_prime}{codon_insert}"
+                                          f"{three_prime}")
                                 add_3 = True
                             primerseq = Seq(primer)
-                            TmNN = mt.Tm_NN(primerseq, strict=False)
-                            primerlength= len(primer)
-                            if seq.index(upperseq) + ((firstcodon - 1) * 3) < flank5:
-                                raise ValueError("Not enough 5' lower case flanking nucleotides")
-                            if lower_3_prime + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
-                                raise ValueError("Not enough 3' lower case flanking nucleotides")
+                            TmNN = ('%0.2f' % mt.Tm_NN(primerseq,
+                                                       strict=False))
+                            primerlength = len(primer)
+                            if (seq.index(upperseq) + ((firstcodon - 1) * 3) <
+                                    flank5):
+                                raise ValueError("Not enough 5' lower case "
+                                                 "flanking nucleotides")
+                            if (lower_3_prime + (len(upperseq) -
+                                    (lastcodon - 1) * 3) < flank3):
+                                raise ValueError("Not enough 3' lower case "
+                                                 "flanking nucleotides")
                     else:
                         pass
                 primers.append((name, primer))
-    #print primers
     return primers
 
 
@@ -267,11 +301,11 @@ def main():
     for (argname, argvalue) in args.items():
         print(f"\t{argname} = {argvalue}")
 
-
     primerlength = args['startprimerlength']
 
-    if (primerlength <=3 ) or (primerlength % 2 == 0):
-        raise ValueError(f"Does not appear to be valid primer length: {primerlength}")
+    if (primerlength <= 3) or (primerlength % 2 == 0):
+        raise ValueError((f"Does not appear to be valid primer length:"
+                          f" {primerlength}"))
 
     sequencefile = args['sequencefile']
     if not os.path.isfile(sequencefile):
@@ -279,7 +313,8 @@ def main():
     sequence = open(sequencefile).read()
     sequence = sequence.replace(' ', '')
     sequence = sequence.replace('\n', '')
-    print(f"Read a sequence of length {len(sequence)} from {sequencefile}:\n{sequence}")
+    print((f"Read a sequence of length {len(sequence)} from "
+           f"{sequencefile}:\n{sequence}"))
     outfile = args['outfile']
     primerprefix = args['primerprefix']
     print(f"The primers will be named with the prefix {primerprefix}")
@@ -290,17 +325,19 @@ def main():
 
     codon_frequency_csv = args['codon_frequency_csv']
     if not os.path.isfile(codon_frequency_csv):
-        raise IOError(f"Cannot find mutatcodon_frequency_csvions_csv {codon_frequency_csv}")
+        raise IOError((f"Cannot find mutatcodon_frequency_csvions_csv "
+                       f"{codon_frequency_csv}"))
 
     # Design forward mutation primers
     mutforprimers = CreateMutForOligosVarLength(sequence, mutations_csv,
-        codon_frequency_csv, primerlength, primerprefix, args['maxprimertm'],
-        args['minprimertm'], args['maxlength'], args['minlength'])
+            codon_frequency_csv, primerlength, primerprefix,
+            args['maxprimertm'], args['minprimertm'], args['maxlength'],
+            args['minlength'])
     print(f"Designed {len(mutforprimers)} mutation forward primers.")
 
     # Design reverse mutation primers
-    mutrevprimers = [(name.replace('for', 'rev'), ReverseComplement(seq))
-                      for (name, seq) in mutforprimers]
+    mutrevprimers = [(name.replace('for', 'rev'),
+                      ReverseComplement(seq)) for (name, seq) in mutforprimers]
     print(f"Designed {len(mutrevprimers)} mutation reverse primers.")
 
     # Print out all of the primers
@@ -314,5 +351,4 @@ def main():
             f.write(f"{name}, {primer}\r\n")
 
 
-
-main() # run the main program
+main()

--- a/create_primers.py
+++ b/create_primers.py
@@ -1,0 +1,261 @@
+"""Script for creating gene assembly primers.
+
+Primers containing specified mutageneic codons at their center are tiled along a gene.
+
+Edited by Caelan Radford in 2020, from the CodonTilingPrimers code written by Jesse Bloom in 2013 and edited by Adam Dingens Nov 2015 to generate primers of differing lengths to all have a Tm of ~60C.
+
+This script first makes an ORIGINAL primer of specified length (default 37 bps).
+If the ORIGINAL primer has a Tm of greater than MaxPrimerTm, then nucleotides are trimmed off one by one (first 5', then 3', then 5' etc) until the Tm is less than MaxPrimerTm. Note that this could be over a degree less than the MaxPrimerTm.
+If the ORIGINAL primer has a Tm less than MinPrimerTm, then nucelotides are added one by one (first 3', then 5', then 3' etc) until the Tm is over MinPrimerTm. Note that this could be over a degree more than the MinPrimerTm
+If the ORIGINAL primer has a Tm of less than MaxPrimerTm but greater than MinPrimerTm, it is not altered.
+The primers are constrained to be between MinPrimerlength and MaxPrimerLength bps long. The Tm of some MaxPrimerLength primers may not be > MinPrimerTemp, and the Tm of some MinPrimerLength primers may not be < MaxPrimerTm.
+
+For command line arguments, run::
+
+    python create_primers.py -h
+
+The  Tm_NN command of the MeltingTemp Module of Biopython (http://biopython.org/DIST/docs/api/Bio.SeqUtils.MeltingTemp-module.html) is used to calculate Tm of primers.
+This calculation is based on nearest neighbor thermodynamics. nucelotides labeled N are given average values in the Tm calculation.
+It is possible to vary salt concentration and other addatives if needed."""
+
+
+import os
+import sys
+import math
+import re
+import argparse
+import pandas as pd
+from Bio.SeqUtils import MeltingTemp as mt
+from Bio.Seq import Seq
+
+
+def Parser():
+    """Returns command line parser."""
+    parser = argparse.ArgumentParser(
+            description='Script by Caelan Radford, Adam Dingens, and Jesse Bloom to design specified codon tiling primers with specific melting temperatures.',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            )
+
+    parser.add_argument('sequencefile', help="the name of a file giving the sequence for which we are designing the primers. This file should only contain the sequence, and should not have any headers or other content. For the sequence, make the 5' and 3' ends that you do not want to mutate in lower case. Make the portion of the coding sequence that you want to tile with ambiguous codons in upper case. Typically, for example, the first site you mutate would be the initial start codon, so the first *ATG* would be the first upper case letter. You must have at least *(startprimerlength - 3) / 2* nucleotides in lower case at each end of the upper case sequence that you are mutating. This is because at least this much flanking sequence is needed to design primers of the indicated length; more sequence may be required if the primer at either end is extended beyond the startprimerlength.")
+    parser.add_argument('mutations_csv', help="the name of a csv file containing a table of specific mutations per site you want to make. It should have one column ('site') with site numbers and one column ('mutant') with amino acid mutants to make at that site. Site 1 is the first codon in the uppercase sequence.")
+    parser.add_argument('codon_frequency_csv', help="the name of a csv file with a table of codon frequencies to be used to determine which codons to mutate to. It should have one column 'aa' with single letter amino acids, one column 'codon' with codons, and one column 'frequency' with codon frequencies. The highest frequency codon for each amino acid is used.")
+    parser.add_argument('primerprefix', help="prefix name to be added to each primer")
+    parser.add_argument('outfile', help='name of primer output file')
+    parser.add_argument('--startprimerlength', type=int, help='starting primer length', default=37)
+    parser.add_argument('--maxprimertm', type=float, help="Upper temperature limit for primers.", default=61)
+    parser.add_argument('--minprimertm', type=float, help="Lower temperature limit for primers.", default=60)
+    parser.add_argument('--minlength', type=int, help='Minimum primer length', default=25)
+    parser.add_argument('--maxlength', type=int, help='Maximum primer length', default=51)
+    return parser
+
+
+def ReverseComplement(seq):
+    """Returns reverse complement of sequence. Preserves upper/lower case."""
+    d = {'A':'T', 'T':'A', 'C':'G', 'G':'C', 'a':'t', 't':'a', 'c':'g', 'g':'c', 'N':'N', 'n':'n', 'S':'S', 's':'s', 'K':'M', 'k':'m'}
+    rc = [d[nt] for nt in seq]
+    rc.reverse()
+    return ''.join(rc)
+
+
+def CreateMutForOligosVarLength(seq, mutations_csv, primerlength, prefix, maxprimertm, minprimertm, maxlength, minlength):
+    """Creates oligos to tile a gene and introduce specified amino acid mutations at each site.
+
+    *seq* : sequence of the gene. The gene itself should be upper case,
+    including the start and stop codons. Any flanking regions should be lower
+    case.
+    There must be >= (primerlength - 3) / 2.0 nucleotides before the first codon
+    mutagenized and after the last codon mutagenized.
+
+    *mutations_csv* : csv file containing a table with the mutations the primers
+    will make to seq. The table should have one column, 'site', with site
+    numbers, and one column, 'mutant', with the single letter amino acid mutant
+    to make at that site. Each site can have mulitple mutants, or none. The site
+    number should denote the number of the codon in the uppercase gene, with the
+    start codon being 1.
+
+    *primerlength* : length of primers. Must be an odd number, so that equal length
+    flanking on each side.
+
+    *prefix* : string prefix attached to primer names.
+
+    Tiles primers across the gene in the forward direction. A unique primer is
+    made for each mutation specified by mutations_csv at each site.
+    Primers are named as follows:
+
+    f"{prefix}-for-mut{i}{mutant}" for 5' tiling primers, where i is the site
+    mutagenized in the gene and mutant is the amino acid the site is mutated to
+    using that primer.
+
+    Returns a list of all these primers as *(name, sequence)* 2-tuples.
+    """
+    n = len(seq)
+    assert primerlength % 2 == 1, "primer length not odd"
+    initial_flanklength = (primerlength - 3) // 2
+    upperseq = ''.join([nt for nt in seq if nt.istitle()])
+    assert upperseq in seq, "upper case nucleotides not substring"
+    assert len(upperseq) % 3 == 0, "length of upper case not multiple of 3"
+    ncodons = len(upperseq) // 3
+
+    # Read in the mutations csv and make sure it is the right format
+    df = pd.read_csv(mutations_csv)
+    try:
+        sites = df['site'].tolist()
+    except:
+        print('mutations_csv must have column "site"')
+    try:
+        mutations = df['mutant'].tolist()
+    except:
+        print('mutations_csv must have column "mutant"')
+    mutations_dict = {}
+    for i, site in enumerate(sites):
+        if site not in mutations_dict:
+            mutations_dict[site] = [mutations[i]]
+        else:
+            mutations_dict[site].append(mutations[i])
+    # Make sure this is enough flanking sequence to make primers
+    initial_flanklength = (primerlength - 3) // 2
+    firstcodon = min(sites)
+    lastcodon = max(sites)
+    startupper = seq.index(upperseq) + ((firstcodon - 1) * 3)
+    if startupper < initial_flanklength:
+        raise ValueError("not enough 5' flanking nucleotides")
+    if n - len(upperseq) - seq.index(upperseq) + (len(upperseq) - (lastcodon - 1) * 3) < initial_flanklength:
+        raise ValueError("not enough 3' flanking nucleotides")
+    # Read in the codon frequency table, make dict for back translating
+    df = pd.read_csv('codon_frequencies.csv')
+    aas = df['aa'].tolist()
+    codons = df['codon'].tolist()
+    frequencies = df['frequency'].tolist()
+    back_t_dict = {}
+    for i, codon in enumerate(codons):
+        if aas[i] not in back_t_dict:
+            back_t_dict[aas[i]] = {}
+            back_t_dict[aas[i]][frequencies[i]] = codon
+        else:
+            back_t_dict[aas[i]][frequencies[i]] = codon
+    # Iterate through the codons and make the specific primers, with most
+    # frequent codon
+    primers = []
+    for icodon in range(ncodons):
+        # Determine what the insert should be for the codon
+        # Replace ambiguous_codon with codon insert later
+        codon_inserts = []
+        if icodon + 1 in mutations_dict:
+            for mutation in mutations_dict[icodon + 1]:
+                max_frequency = max(back_t_dict[mutation])
+                codon_insert = back_t_dict[mutation][max_frequency]
+                i = startupper + icodon * 3
+                primer = "%s%s%s" % (seq[i - initial_flanklength : i], codon_insert, seq[i + 3 : i + 3 + initial_flanklength])
+                name = f"{prefix}-for-mut{icodon + 1}{mutation}"
+                primerseq = Seq(primer)
+
+                TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                add_3 = True
+                minus_5 = True
+                flank5 = flank3 = initial_flanklength
+                if float(TmNN) > float(maxprimertm):
+                    while float(TmNN) > float(maxprimertm) and len(primer) > minlength:
+                        if minus_5:
+                            flank5 -= 1
+                            primer = "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+                            minus_5 = False
+                        else:
+                            flank3 -= 1
+                            primer =  "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+
+                            minus_5 = True
+                        if seq.index(upperseq) + ((firstcodon - 1) * 3) < flank5:
+                            raise ValueError("not enough 5' lower case flanking nucleotides")
+                        if n - len(upperseq) - seq.index(upperseq) + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
+                            raise ValueError("not enough 3' lower case flanking nucleotides")
+
+
+                        primerseq = Seq(primer)
+                        TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                        primerlength= len(primer)
+                else:
+                    if float(TmNN) < float(minprimertm):
+                        while float(TmNN) < float(minprimertm) and len(primer) < maxlength:
+                            if add_3:
+                                flank3 += 1
+                                primer = "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+                                add_3 = False
+                            else:
+                                flank5 +=1
+                                primer = "%s%s%s" % (seq[i - (flank5) : i], codon_insert, seq[i + 3 : i + 3 + flank3])
+                                add_3 = True
+                            primerseq = Seq(primer)
+                            TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False))
+                            primerlength= len(primer)
+                            if seq.index(upperseq) + ((firstcodon - 1) * 3) < flank5:
+                                raise ValueError("not enough 5' lower case flanking nucleotides")
+                            if n - len(upperseq) - seq.index(upperseq) + (len(upperseq) - (lastcodon - 1) * 3) < flank3:
+                                raise ValueError("not enough 3' lower case flanking nucleotides")
+
+                    else:
+                        pass
+                primers.append((name, primer))
+    #print primers
+    return primers
+
+
+def main():
+    parser = Parser()
+    args = vars(parser.parse_args())
+
+    print("Read the following command line arguments")
+    for (argname, argvalue) in args.items():
+        print("\t%s = %s" % (argname, argvalue))
+
+
+    primerlength = args['startprimerlength']
+
+    if (primerlength <=3 ) or (primerlength % 2 == 0):
+        raise ValueError("Does not appear to be valid primer length: %d" % primerlength)
+
+    sequencefile = args['sequencefile']
+    if not os.path.isfile(sequencefile):
+        raise IOError("Cannot find sequencefile %s" % sequencefile)
+    sequence = open(sequencefile).read()
+    sequence = sequence.replace(' ', '')
+    sequence = sequence.replace('\n', '')
+    print("Read a sequence of length %d from %s:\n%s" % (len(sequence), sequencefile, sequence))
+    outfile = args['outfile']
+    primerprefix = args['primerprefix']
+    print("The primers will be named with the prefix %s" % (primerprefix))
+
+    mutations_csv = args['mutations_csv']
+    if not os.path.isfile(mutations_csv):
+        raise IOError(f"Cannot find mutations_csv {mutations_csv}")
+
+    # Design forward mutation primers
+    mutforprimers = CreateMutForOligosVarLength(sequence, mutations_csv, primerlength, primerprefix, args['maxprimertm'], args['minprimertm'], args['maxlength'], args['minlength'])
+    print("Designed %d mutation forward primers." % len(mutforprimers))
+
+    # Design reverse mutation primers
+    mutrevprimers = [(name.replace('for', 'rev'), ReverseComplement(seq)) for (name, seq) in mutforprimers]
+    print("Designed %d mutation reverse primers." % len(mutrevprimers))
+
+    # Print out all of the primers
+    primers = mutforprimers + mutrevprimers
+    print("This gives a total of %d primers." % len(primers))
+
+    print("\nNow writing these primers to %s" % outfile)
+    iplate = 1
+    f = open(outfile, 'w')
+    for primers in [mutforprimers, mutrevprimers]:
+        f.write("\r\nPlate %d\r\n" % iplate)
+        n_in_plate = 0
+        for (name, primer) in primers:
+            f.write("%s, %s\r\n" % (name, primer))
+            n_in_plate += 1
+            if n_in_plate == 96:
+                n_in_plate = 0
+                iplate += 1
+                f.write("\r\nPlate %d\r\n" % iplate)
+        if n_in_plate:
+            iplate += 1
+
+
+
+main() # run the main program


### PR DESCRIPTION
This adds the initial edited script from CodonTilingPrimers and an updated README to describe what the changes do. Here is a short summary: 
- You must now pass a csv file as an argument that specifies what mutants to make at what sites 
- You must now pass a codon frequency csv file as an argument that determines what codon will to mutated to for each amino acid 
- The gene sequence given in a text file should now be uppercase for the WHOLE gene, including the start and stop codons 
- The gene sequence given in a text file no longer necessarily has to have lower case sequence before and after the gene; there must only be enough room for primer overhangs before the first codon mutagenized and after the last codon mutagenized
- As is written right now, there is no option for degenerate codons, which is why this is a new repository. This functionality could be added back later 

More functionality could be added later, like randomly picking codons for an amino acid as an option, or picking weighted on frequencies, etc. If this edit looks ok, I'll make a test case with BF520 primers and add them to the repo. I am still also making sure it is working properly; just wanted to make sure this approach looked ok in the meantime. 