### PR TITLE
Adds options for codon selection/multiple codons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [create_primers.py](create_primers.py) Python script can be used to create p
 
 *seq* : Text file containing the sequence of the gene. The gene itself should be upper case, including the start and stop codons. Any flanking regions should be lower case. There must be >= (primerlength - 3) / 2.0 nucleotides before the first codon mutagenized and after the last codon mutagenized, otherwise there would not be enough flanking nucleotides for a primer to mutate those codons.
 
-*mutations_csv* : csv file containing a table with the mutations the primers will make to seq. The table should have a column, 'site', with site numbers, and a column, 'mutant', with the single letter amino acid mutant to make at that site. Each site can have multiple mutants, or none. The site number should denote the number of the codon in the uppercase gene, with the start codon being 1. If you want multiple mutations at the same site, there should be a separate row for each mutation.
+*mutations_csv* : csv file containing a table with the mutations the primers will make to seq. The table should have a column, 'site', with site numbers, a column, 'mutant', with the single letter amino acid mutant to make at that site, and a column, 'num_codons', with the number of codon mutations to make  for that amino acid at that site. The optional argument 'codon_selection' be  used to change how codons are selected.Each site can have multiple mutants, or none. The site number should denote the number of the codon in the uppercase gene, with the start codon being 1. If you want multiple mutations at the same site, there should be a separate row for each mutation.
 
 *codon_frequency_csv* : csv file containing a table with codon frequencies used to determine which codons sites will be mutated to. The table should have the columns 'aa', 'codon', and 'frequency'. Each row should have one single letter amino acid in 'aa', one codon corresponding to that amino acid in 'codon', and the frequency of that codon in 'frequency'. The script uses the codon with the highest frequency to replace the codon at a site to make mutations. Codon frequency tables for different organisms can be found [here](https://www.kazusa.or.jp/codon/).
 
@@ -40,15 +40,15 @@ There are a variety of optional parameters specifying primer length and melting 
 
 The script works as follows:
 
-    1) `mutations_csv` is used to determine what mutations will be made at what sites.
+1) `mutations_csv` is used to determine what mutations will be made at what sites.
 
-    2) For each site, the frequencies from `codon_frequency_csv` are used to determine what the most frequent codon is for each mutation to be made at that site. This codon will be made by the primer for that mutation at that site.
+2) For each site and amino acid mutation, the frequencies from `codon_frequency_csv` along with the optional arguments `codon_selection` and `min_codon_frequency` are used to determine which codon mutations to make. Either the most frequent codons are used for each mutation to be made at that site, or random codons are chosen. These codons will be made by the primers created for that mutation at that site.
 
-    3) For each mutant codon, it first makes an ORIGINAL primer of the length specified by `--startprimerlength`
+3) For each mutant codon, it first makes an ORIGINAL primer of the length specified by `--startprimerlength`
 
-    4) If the original primer has a melting temperature (Tm) greater than the value specified by `--maxprimertm`, then nucleotides are trimmed off one by one (first from the 5' end, then the 3' end, then the 5' end again, etc) until the melting temperature is less than `--maxprimertm` or the length is reduced to `--minlength`.
+4) If the original primer has a melting temperature (Tm) greater than the value specified by `--maxprimertm`, then nucleotides are trimmed off one by one (first from the 5' end, then the 3' end, then the 5' end again, etc) until the melting temperature is less than `--maxprimertm` or the length is reduced to `--minlength`.
 
-    5) If the original primer has a Tm greater than `--minprimertm`, then nucleotides are added one-by-one (first to the 3' end, then the 5' end, then the 3' end again, etc) until the melting temperature is greater than `--minprimertm` or the length reaches `--maxlength`.
+5) If the original primer has a Tm greater than `--minprimertm`, then nucleotides are added one-by-one (first to the 3' end, then the 5' end, then the 3' end again, etc) until the melting temperature is greater than `--minprimertm` or the length reaches `--maxlength`.
 
 Note that because the primers are constrained to be between `--minprimerlength` and `--maxprimerlength`, the Tm may not always fall between `--minprimertm` and `--maxprimertm`. This can also happen if a primer initially exceeds `--maxprimertm` but the first trimming that drops it below this value also drops it below `--minprimertm`, or vice-versa if the primer is being extended to increase its melting temperature.
 

--- a/create_primers.py
+++ b/create_primers.py
@@ -371,10 +371,12 @@ def main():
     print(f"This gives a total of {len(primers)} primers.")
 
     print(f"\nNow writing these primers to {outfile}")
-    f = open(outfile, 'w')
-    for primers in [mutforprimers, mutrevprimers]:
-        for (name, primer) in primers:
-            f.write(f"{name}, {primer}\r\n")
+    f = open(f"{outfile}_for.csv", 'w')
+    for (name, primer) in mutforprimers:
+        f.write(f"{name},{primer}\r\n")
+    f = open(f"{outfile}_rev.csv", 'w')
+    for (name, primer) in mutrevprimers:
+        f.write(f"{name},{primer}\r\n")
 
 
 main()


### PR DESCRIPTION
I have modified the script more to be able to produce multiple codon mutations per site and to allow the user to determine how codons are chosen. Here is a summary of the changes: 
- There are two new optional arguments: 'codon_selection' and 'min_codon_frequency'. 'codon_selection' must either be 'highest_frequency' or 'random', and determines how the codons are chosen for each mutation. Chosen codons are always above the frequency 'min_codon_frequency'. 
- 'mutations_csv' must now have a column 'num_codons'. The column must have the number of codon mutations to generate for that row's site and mutant. If too many codons are specified for that mutation (which might happen often, especially if someone tries to do multiple codons for M or W), the script throws an error that specifies which site and mutation has too many codons requested. 

I still don't have a test for the code. I have been testing it with a dataframe from my BF520 analysis, and making sure the output primers make sense. I am not sure what the best strategy for testing is now that I have added the option to make the outputs semi-random. However, 'codon_selection' is 'highest_frequency', the output should be the same every time, so I was thinking I would write a test for that. 